### PR TITLE
Convert line number to integer on inline comment

### DIFF
--- a/lib/pep8/plugin.rb
+++ b/lib/pep8/plugin.rb
@@ -121,7 +121,7 @@ module Danger
     def comment_inline(errors=[])
       errors.each do |error|
         file, line, column, reason = error.split(":")
-        message(reason.strip.gsub("'", "`"), file: file, line: line)
+        message(reason.strip.gsub("'", "`"), file: file, line: line.to_i)
       end
     end
 


### PR DESCRIPTION
Using inline comments often results with an exception:

```
/home/ubuntu/.rvm/gems/ruby-2.4.0/gems/octokit-4.7.0/lib/octokit/response/raise_error.rb:16:in `on_complete': POST https://api.github.com/repos/saluspot/saluspot/pulls/2920/comments: 422 - Validation Failed (Octokit::UnprocessableEntity)
Error summary:
  resource: PullRequestReviewComment
  code: invalid
  field: position // See: https://developer.github.com/v3/pulls/comments/#create-a-comment
```

After doing some manual tests on a Dangerfile calling flake8 directly I noticed that if the `line` argument is sent as string some API calls fail. Converting the parameter to integer before creating the violation solves the problem.